### PR TITLE
Leverage macos platform tag autodetect in `wheel>=0.34`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,12 +185,6 @@ jobs:
     macos:
       xcode: << parameters.xcode >>
 
-    environment:
-      # Force (lie about) macOS 10.9 binary compatibility.
-      # Needed for properly versioned wheels.
-      # See: https://github.com/MacPython/wiki/wiki/Spinning-wheels
-      MACOSX_DEPLOYMENT_TARGET: 10.9
-
     steps:
       - checkout
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "setuptools>=46.4.0",       # PEP-420 support, PEP-517/518 support, setup.cfg attr: support
-    "wheel>=0.30.0",            # limited python api support
+    "wheel>=0.34.0",            # limited python api support, macos binary wheels platform tag auto-detect
     "cython>=0.29.23,<3.0",
     "numpy==1.19.4",
 ]


### PR DESCRIPTION
Previously, `MACOSX_DEPLOYMENT_TARGET` had to be manually set during binary wheel build.

The latest `wheel` version is now able to auto-detect the platform tag, setting it to the lowest possible/compatible version. Currently, we target for 10.9.