### PR TITLE
Add option to SteepestDescentComposite to select only the n best (lowest energy) samples from the child as initial states

### DIFF
--- a/greedy/composite.py
+++ b/greedy/composite.py
@@ -43,8 +43,9 @@ class SteepestDescentComposite(dimod.ComposedSampler):
 
     """
 
-    def __init__(self, child_sampler):
+    def __init__(self, child_sampler, n_best=None):
         self.children = [child_sampler]
+        self._n_best = n_best
 
         # set the parameters
         self.parameters = child_sampler.parameters.copy()
@@ -90,4 +91,9 @@ class SteepestDescentComposite(dimod.ComposedSampler):
 
         greedy_sampler = greedy.SteepestDescentSolver()
 
-        return greedy_sampler.sample(bqm, initial_states=sampleset)
+        if self._n_best:
+            initial_states = list(sampleset.samples())[:self._n_best]
+        else:
+            initial_states = sampleset
+
+        return greedy_sampler.sample(bqm, initial_states=initial_states)

--- a/greedy/composite.py
+++ b/greedy/composite.py
@@ -91,7 +91,7 @@ class SteepestDescentComposite(dimod.ComposedSampler):
 
         greedy_sampler = greedy.SteepestDescentSolver()
 
-        if self._n_best:
+        if self._n_best is not None:
             initial_states = list(sampleset.samples())[:self._n_best]
         else:
             initial_states = sampleset

--- a/tests/test_composite.py
+++ b/tests/test_composite.py
@@ -61,3 +61,11 @@ class TestSteepestDescendComposite(unittest.TestCase):
 
         np.testing.assert_array_almost_equal(
             sampleset.record.sample, ground.record.sample)
+
+    def test_n_best(self):
+        bqm = dimod.BQM({x: x for x in range(4)}, {(2, 3): -6}, 'BINARY')
+
+        sampler = SteepestDescentComposite(dimod.ExactSolver(), n_best=1)
+        sampleset = sampler.sample(bqm).aggregate()
+
+        np.testing.assert_array_equal(sampleset.record.sample, [[0, 0, 1, 1]])


### PR DESCRIPTION
This change is useful for decoupling the time/effort spent by `SteepestDescentComposite` from the time/effort spent by the child sampler.