### PR TITLE
Fix deploy of aarch64 wheels

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,6 +101,7 @@ workflows:
           requires:
             - ocean/build-sdist
             - ocean/build-manylinux-wheel
+            - ocean/cibw-build-linux-aarch64-wheel
           post-steps:
             - run: make -C tests/
           matrix:


### PR DESCRIPTION
Currently, they are only built, but not tested/deployed.