### PR TITLE
Fix tests to work with new `MockDWaveSampler`

### DIFF
--- a/tests/test_composite.py
+++ b/tests/test_composite.py
@@ -37,7 +37,8 @@ class TestSteepestDescendComposite(unittest.TestCase):
         J = {(0, 4): 1.5}
         num_reads = 100
 
-        response = sampler.sample_ising(h, J, num_reads=num_reads)
+        # make sure samples are not aggregated with answer_mode='raw'
+        response = sampler.sample_ising(h, J, num_reads=num_reads, answer_mode='raw')
 
         self.assertEqual(len(response), num_reads)
 


### PR DESCRIPTION
The new mock sampler (released in dwave-system 1.15.1) aggregates samples in the returned sampleset by default, just like the QPU does (i.e. it uses `answer_mode='histogram'`).

To fix our greedy composite tests, we request an unaggregated sampleset.